### PR TITLE
Fix potential multi-threading problems

### DIFF
--- a/Core/Theraot/Threading/Needles/Needle.cs
+++ b/Core/Theraot/Threading/Needles/Needle.cs
@@ -49,7 +49,7 @@ namespace Theraot.Threading.Needles
             get
             {
                 var target = _target;
-                return !ReferenceEquals(_target, null) && target.IsAlive;
+                return !ReferenceEquals(target, null) && target.IsAlive;
             }
         }
 


### PR DESCRIPTION
This is an issue that I found when browsing the code. It could be a non-issue though if you have special reason that _target should be used instead.