### PR TITLE
Fix build warning

### DIFF
--- a/Tests/System/Linq/Expressions/ExpressionTest_Utils.cs
+++ b/Tests/System/Linq/Expressions/ExpressionTest_Utils.cs
@@ -208,7 +208,9 @@ namespace MonoTests.System.Linq.Expressions
 
         public delegate int Delegate(int i);
 
+#pragma warning disable 67
         public event Delegate OnTest;
+#pragma warning restore 67
 
         public void DoNothing()
         {


### PR DESCRIPTION
```
        System\Linq\Expressions\ExpressionTest_Utils.cs(211,31): warning CS0067: The event 'MemberClass.OnTest' is never used
```