### PR TITLE
Minimal changes to support Expression.GetDelegateType

### DIFF
--- a/Framework.Core/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/Framework.Core/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -1,4 +1,4 @@
-﻿#if LESSTHAN_NET35
+﻿#if LESSTHAN_NET40
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.

--- a/Framework.Core/System/Linq/Expressions/Compiler/DelegateHelpers.cache.cs
+++ b/Framework.Core/System/Linq/Expressions/Compiler/DelegateHelpers.cache.cs
@@ -1,4 +1,4 @@
-﻿#if LESSTHAN_NET35
+﻿#if LESSTHAN_NET40
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.

--- a/Framework.Core/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/Framework.Core/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -1,4 +1,4 @@
-﻿#if LESSTHAN_NET35
+﻿#if LESSTHAN_NET40
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -20,6 +20,7 @@ namespace System.Linq.Expressions.Compiler
 
         private static readonly Type[] _delegateCtorSignature = { typeof(object), typeof(IntPtr) };
 
+#if LESSTHAN_NET35
         internal static Type MakeCallSiteDelegate(Expression[] types, Type returnType)
         {
             lock (_delegateCache)
@@ -98,6 +99,7 @@ namespace System.Linq.Expressions.Compiler
         {
             return mo.Expression is ParameterExpression pe && pe.IsByRef;
         }
+#endif
 
         private static Type MakeNewCustomDelegate(Type[] types)
         {

--- a/Framework.Core/System/Linq/Expressions/LambdaExpression.cs
+++ b/Framework.Core/System/Linq/Expressions/LambdaExpression.cs
@@ -1,4 +1,4 @@
-﻿#if LESSTHAN_NET35
+﻿#if LESSTHAN_NET40
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
@@ -21,6 +21,7 @@ using DelegateHelpers = System.Linq.Expressions.Compiler.DelegateHelpers;
 
 namespace System.Linq.Expressions
 {
+#if LESSTHAN_NET35
     /// <inheritdoc />
     /// <summary>
     ///     Defines a <see cref="Expression{TDelegate}"/> node.
@@ -160,7 +161,40 @@ namespace System.Linq.Expressions
             return visitor.VisitLambda(this);
         }
     }
+#endif
 
+#if LESSTHAN_NET35
+    public partial class Expression
+#else
+    public static partial class ExpressionEx
+#endif
+    {
+        /// <summary>
+        ///     Gets a <see cref="System.Type" /> object that represents a generic System.Func or System.Action delegate type that
+        ///     has specific type arguments.
+        ///     The last type argument determines the return type of the delegate. If no Func or Action is large enough, it will
+        ///     generate a custom
+        ///     delegate type.
+        /// </summary>
+        /// <param name="typeArgs">
+        ///     An array of <see cref="System.Type" /> objects that specify the type arguments of the delegate
+        ///     type.
+        /// </param>
+        /// <returns>The delegate type.</returns>
+        /// <remarks>
+        ///     As with Func, the last argument is the return type. It can be set
+        ///     to <see cref="System.Void" /> to produce an Action.
+        /// </remarks>
+        public static Type GetDelegateType(params Type[] typeArgs)
+        {
+            ContractUtils.RequiresNotNull(typeArgs, nameof(typeArgs));
+            ContractUtils.RequiresNotEmpty(typeArgs, nameof(typeArgs));
+            ContractUtils.RequiresNotNullItems(typeArgs, nameof(typeArgs));
+            return DelegateHelpers.MakeDelegateType(typeArgs);
+        }
+    }
+
+#if LESSTHAN_NET35
     public partial class Expression
     {
         private enum TryGetFuncActionArgsResult
@@ -200,30 +234,6 @@ namespace System.Linq.Expressions
 
                     return result;
             }
-        }
-
-        /// <summary>
-        ///     Gets a <see cref="System.Type" /> object that represents a generic System.Func or System.Action delegate type that
-        ///     has specific type arguments.
-        ///     The last type argument determines the return type of the delegate. If no Func or Action is large enough, it will
-        ///     generate a custom
-        ///     delegate type.
-        /// </summary>
-        /// <param name="typeArgs">
-        ///     An array of <see cref="System.Type" /> objects that specify the type arguments of the delegate
-        ///     type.
-        /// </param>
-        /// <returns>The delegate type.</returns>
-        /// <remarks>
-        ///     As with Func, the last argument is the return type. It can be set
-        ///     to <see cref="System.Void" /> to produce an Action.
-        /// </remarks>
-        public static Type GetDelegateType(params Type[] typeArgs)
-        {
-            ContractUtils.RequiresNotNull(typeArgs, nameof(typeArgs));
-            ContractUtils.RequiresNotEmpty(typeArgs, nameof(typeArgs));
-            ContractUtils.RequiresNotNullItems(typeArgs, nameof(typeArgs));
-            return DelegateHelpers.MakeDelegateType(typeArgs);
         }
 
         /// <summary>
@@ -1319,6 +1329,7 @@ namespace System.Linq.Expressions
         internal override string? NameCore { get; }
         internal override bool TailCallCore { get; }
     }
+#endif
 }
 
 #endif


### PR DESCRIPTION
See #110 

Implemented as ExpressionEx.GetDelegateType for .NET Framework 3.5 build only. Pre-3.5 and Post-3.5 users will continue to see it as Expression.GetDelegateType.

There's actually a whole bunch of LINQ/Expression stuff that's in 4.0 but not in 3.5, such that oddly enough, pre-3.5 users of Theraot have more a complete LINQ/Expression implementation than 3.5 users. I had to make minimal changes, or otherwise I would've pulled in a lot of extra baggage, including a lot of 4.0+ Dynamic support.