### PR TITLE
Fix Span and ReadOnlySpan

### DIFF
--- a/Framework.Core/System/ReadOnlySpan.cs
+++ b/Framework.Core/System/ReadOnlySpan.cs
@@ -140,7 +140,7 @@ namespace System
 
         public override string ToString()
         {
-            return string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
+            return string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
         }
 
         public bool TryCopyTo(Span<T> destination)

--- a/Framework.Core/System/ReadOnlySpan.cs
+++ b/Framework.Core/System/ReadOnlySpan.cs
@@ -6,6 +6,8 @@
 #pragma warning disable CA1815 // override equality and inequality
 #pragma warning disable CA2225 // Provide a method as alternative to operator implicit
 
+using System.Text;
+
 namespace System
 {
     public ref struct ReadOnlySpan<T>
@@ -140,6 +142,23 @@ namespace System
 
         public override string ToString()
         {
+            if (typeof(T) == typeof(char))
+            {
+                StringBuilder builder = new();
+
+                foreach (T? character in this)
+                {
+                    // This condition only exists to cast T as char as this should always be true.
+                    // The original uses Unsafe.As<T>, but until it is polyfilled, it has to be done like this.
+                    if (character is char c)
+                    {
+                        builder.Append(c);
+                    }
+                }
+
+                return builder.ToString();
+            }
+
             return string.Format("System.ReadOnlySpan<{0}>[{1}]", typeof(T).Name, _length);
         }
 

--- a/Framework.Core/System/ReadOnlySpan.cs
+++ b/Framework.Core/System/ReadOnlySpan.cs
@@ -179,9 +179,6 @@ namespace System
         public static implicit operator ReadOnlySpan<T>(ArraySegment<T> segment)
             => new ReadOnlySpan<T>(segment.Array, segment.Offset, segment.Count);
 
-        public static implicit operator ReadOnlySpan<T>(Span<T> span) =>
-            new ReadOnlySpan<T>(span._array, span._start, span._length);
-
         /// <summary>
         ///  From .NET source
         /// </summary>

--- a/Framework.Core/System/Span.cs
+++ b/Framework.Core/System/Span.cs
@@ -7,6 +7,8 @@
 #pragma warning disable CA2225 // Provide a method as alternative to operator implicit
 #pragma warning disable IDE0011 // Add braces
 
+using System.Text;
+
 namespace System
 {
     public ref struct Span<T>
@@ -157,6 +159,23 @@ namespace System
 
         public override string ToString()
         {
+            if (typeof(T) == typeof(char))
+            {
+                StringBuilder builder = new();
+
+                foreach (T? character in this)
+                {
+                    // This condition only exists to cast T as char as this should always be true.
+                    // The original uses Unsafe.As<T>, but until it is polyfilled, it has to be done like this.
+                    if (character is char c)
+                    {
+                        builder.Append(c);
+                    }
+                }
+
+                return builder.ToString();
+            }
+
             return string.Format("System.Span<{0}>[{1}]", typeof(T).Name, _length);
         }
 


### PR DESCRIPTION
## Problems that this pull request addresses

#### Removed duplicate implicit conversion from Span to ReadOnlySpan

- `ReadOnlySpan` and `Span` both define conversions from `Span` to `ReadOnlySpan`, making it impossible to actually convert between them (see image). The C# runtime source code for [`Span`](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/Span.cs#L396) does define a conversion while [`ReadOnlySpan`](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs) doesn't. 

![bild](https://user-images.githubusercontent.com/14614115/143514977-5dc789d5-e57b-44ec-849f-ba760f83dd72.png)

#### Fixed ReadOnlySpan's ToString format

- `ReadOnlySpan`'s `ToString()` method should return `System.ReadOnlySpan<T>[x]` according to the [runtime source](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/ReadOnlySpan.cs#L336), but in this library it returns `System.Span<T>[x]`.

#### Added char concatenation if ReadOnlySpan and Span generic is char

- Both `Span`'s and `ReadOnlySpan`'s `ToString()` method do not implement `char` concatenation, which makes sense as `Unsafe.As<T>` is not easy, if not impossible to port. However `StringBuilder` might be a decent alternative, it's slower but I think it's worth sacrificing performance in this case. You can also perhaps implement the pattern shown in that commit to polyfill most of the remainder missing code in `MemoryExtensions`.