### PR TITLE
remove redundant cast

### DIFF
--- a/Framework.Core/Theraot/Collections/Extensions.operations.cs
+++ b/Framework.Core/Theraot/Collections/Extensions.operations.cs
@@ -579,20 +579,20 @@ namespace Theraot.Collections
                 return readOnlyCollectionEx.Wrapped is T[] wrappedArray ? wrappedArray : readOnlyCollectionEx.ToArray();
             }
 
-            if (source is ICollection<T> collection1 && collection1.Count == 0)
+            if (source is ICollection<T> collection)
             {
-                return ArrayEx.Empty<T>();
+                if (collection.Count == 0)
+                {
+                    return ArrayEx.Empty<T>();
+                }
+
+                var result = new T[collection.Count];
+                collection.CopyTo(result, 0);
+                return result;
             }
 
-            if (source is not ICollection<T> collection2)
-            {
-                // ReSharper disable once RemoveConstructorInvocation
-                return new List<T>(source).ToArray();
-            }
-
-            var result = new T[collection2.Count];
-            collection2.CopyTo(result, 0);
-            return result;
+            // ReSharper disable once RemoveConstructorInvocation
+            return new List<T>(source).ToArray();
         }
     }
 


### PR DESCRIPTION
casting variant generics is not fast operation.
see https://www.danielcrabtree.com/blog/214/covariant-and-contravariant-casting-is-3x-slower-than-dynamic
dotnet/runtime#4090