### PR TITLE
backport Type.IsAssignableTo(Type); backport Type.GenericTypeArguments

### DIFF
--- a/Framework.Core/System/Reflection/TypeTheraotExtensions.cs
+++ b/Framework.Core/System/Reflection/TypeTheraotExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System.Reflection;
+
+public static class TypeTheraotExtensions
+{
+#if NETFRAMEWORK && !NET45_OR_GREATER
+    public static Type[] GenericTypeArguments(this Type @this) => @this.GetGenericArguments();
+#endif
+#if !NET5_0_OR_GREATER
+    // [Intrinsic]
+    public static bool IsAssignableTo(this Type @this, [NotNullWhen(true)]Type? targetType)
+        => targetType?.IsAssignableFrom(@this) ?? false;
+#endif
+}


### PR DESCRIPTION
I think it's ok to leave empty `TypeTheraotExtensions` to simplify ifdefs. There is no chance .net team will add name like that.